### PR TITLE
ui: Use pixelSize instead of pointSize for fonts

### DIFF
--- a/ui/FluidStyle.qml
+++ b/ui/FluidStyle.qml
@@ -20,35 +20,35 @@ QtObject {
     readonly property color iconColorDark: Qt.rgba(1,1,1)
 
     readonly property font display4Font: Qt.font({ family: "Roboto", weight: Font.Light,
-                                                   pointSize: 112 })
+                                                   pixelSize: 112 })
 
-    readonly property font display3Font: Qt.font({ family: "Roboto", pointSize: 56 })
+    readonly property font display3Font: Qt.font({ family: "Roboto", pixelSize: 56 })
 
-    readonly property font display2Font: Qt.font({ family: "Roboto", pointSize: 45 })
+    readonly property font display2Font: Qt.font({ family: "Roboto", pixelSize: 45 })
 
-    readonly property font display1Font: Qt.font({ family: "Roboto", pointSize: 34 })
+    readonly property font display1Font: Qt.font({ family: "Roboto", pixelSize: 34 })
 
-    readonly property font headlineFont: Qt.font({ family: "Roboto", pointSize: 24 })
+    readonly property font headlineFont: Qt.font({ family: "Roboto", pixelSize: 24 })
 
     readonly property font titleFont: Qt.font({ family: "Roboto", weight: Font.DemiBold,
-                                                pointSize: 20 })
+                                                pixelSize: 20 })
 
     readonly property font subheadingFont: Qt.font({ family: "Roboto",
-                                                     pointSize: Device.isMobile ? 16 : 15 })
+                                                     pixelSize: Device.isMobile ? 16 : 15 })
 
     readonly property font body2Font: Qt.font({ family: "Roboto",
-                                                pointSize: Device.isMobile ? 14 : 13 })
+                                                pixelSize: Device.isMobile ? 14 : 13 })
 
     readonly property font body1Font: Qt.font({ family: "Roboto", weight: Font.DemiBold,
-                                                pointSize: Device.isMobile ? 14 : 13 })
+                                                pixelSize: Device.isMobile ? 14 : 13 })
 
-    readonly property font captionFont: Qt.font({ family: "Roboto", pointSize: 12 })
+    readonly property font captionFont: Qt.font({ family: "Roboto", pixelSize: 12 })
 
     readonly property font buttonFont: Qt.font({ family: "Roboto", weight: Font.DemiBold,
-                                                 pointSize: 14, capitalization: Font.AllUppercase })
+                                                 pixelSize: 14, capitalization: Font.AllUppercase })
 
     /* Control fonts that don't fit into the standard font styles */
 
     readonly property font subheaderFont: Qt.font({ family: "Roboto", weight: Font.DemiBold,
-                                                    pointSize: 14 })
+                                                    pixelSize: 14 })
 }


### PR DESCRIPTION
pointSize is too large on a hidpi monitor (MacBook Pro, Arch Linux).

@plfiorini Could you give this a try on your system and see if it looks correct?

Too large (using pointSize):

![fluid demo_011](https://cloud.githubusercontent.com/assets/3230912/16857990/37427992-49e9-11e6-95b3-180b0e3dea97.png)

Correct size (using pixelSize):

![fluid demo_010](https://cloud.githubusercontent.com/assets/3230912/16857999/49f20404-49e9-11e6-8741-d2da534c0c8d.png)

