### PR TITLE
Standard text components

### DIFF
--- a/demo/TypographyPage.qml
+++ b/demo/TypographyPage.qml
@@ -1,0 +1,78 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.0
+import QtQuick.Layouts 1.0
+import QtQuick.Controls 2.0
+import Fluid.UI 1.0
+
+Page {
+    title: "Typography"
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 8
+
+        DisplayLabel {
+            level: 4
+            text: "Display 4"
+        }
+
+        DisplayLabel {
+            level: 3
+            text: "Display 3"
+        }
+
+        DisplayLabel {
+            level: 2
+            text: "Display 2"
+        }
+
+        DisplayLabel {
+            level: 1
+            text: "Display 1"
+        }
+
+        HeadlineLabel {
+            text: "Headline"
+        }
+
+        TitleLabel {
+            text: "Title"
+        }
+
+        SubheadingLabel {
+            text: "Subheading"
+        }
+
+        BodyLabel {
+            level: 2
+            text: "Body 2"
+        }
+
+        BodyLabel {
+            level: 1
+            text: "Body 1"
+        }
+
+        CaptionLabel {
+            text: "Caption"
+        }
+
+        Label {
+            text: "Label"
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/demo/demo.qrc
+++ b/demo/demo.qrc
@@ -3,6 +3,7 @@
 
 <qresource>
 	<file>main.qml</file>
+	<file>TypographyPage.qml</file>
 	<file>SubPage.qml</file>
 </qresource>
 

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -7,7 +7,7 @@ FluidWindow {
     visible: true
 
     width: 600
-    height: 450
+    height: 650
 
     title: "Fluid Demo"
 
@@ -16,15 +16,22 @@ FluidWindow {
 
         ListView {
             anchors.fill: parent
-            model: 5
+            model: ListModel {
+                ListElement { title: "Typography"; source: "qrc:/TypographyPage.qml" }
+                ListElement { title: "List Item 1"; source: "qrc:/SubPage.qml" }
+                ListElement { title: "List Item 2"; source: "qrc:/SubPage.qml" }
+                ListElement { title: "List Item 3"; source: "qrc:/SubPage.qml" }
+                ListElement { title: "List Item 4"; source: "qrc:/SubPage.qml" }
+            }
             header: Subheader {
                 text: "Header"
             }
-
             delegate: ListItem {
-                text: "List Item " + (index + 1)
-                onClicked: pageStack.push(Qt.resolvedUrl('SubPage.qml'))
+                text: model.title
+                onClicked: pageStack.push(model.source)
             }
+
+            ScrollIndicator.vertical: ScrollIndicator {}
         }
     }
 }

--- a/tests/auto/material/CMakeLists.txt
+++ b/tests/auto/material/CMakeLists.txt
@@ -4,7 +4,9 @@ set(CMAKE_MACOSX_BUNDLE FALSE)
 
 add_definitions(-DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_executable(tst_material ${SOURCES})
-target_link_libraries(tst_material Qt5::Qml Qt5::Test Qt5::QuickTest)
+qt5_add_resources(RESOURCES material.qrc)
+
+add_executable(tst_material ${SOURCES} ${RESOURCES})
+target_link_libraries(tst_material Qt5::Qml Qt5::QuickControls2 Qt5::Test Qt5::QuickTest)
 add_test(tst_material tst_material)
 add_dependencies(check tst_material)

--- a/tests/auto/material/material.qrc
+++ b/tests/auto/material/material.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="/">
+    <file>qtquickcontrols2.conf</file>
+</qresource>
+</RCC>

--- a/tests/auto/material/qtquickcontrols2.conf
+++ b/tests/auto/material/qtquickcontrols2.conf
@@ -1,0 +1,2 @@
+[Controls]
+Style=Material

--- a/tests/auto/material/tst_typography.qml
+++ b/tests/auto/material/tst_typography.qml
@@ -1,0 +1,162 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import QtTest 1.0
+import Fluid.Core 1.0
+import Fluid.UI 1.0
+import QtQuick.Controls 2.0
+
+TestCase {
+    id: testCase
+    name: "TypographyTests"
+    width: 200
+    height: 200
+    visible: true
+    when: windowShown
+
+    Component {
+        id: displayLabelComponent
+        DisplayLabel {}
+    }
+
+    Component {
+        id: bodyLabelComponent
+        BodyLabel {}
+    }
+
+    Component {
+        id: captionLabelComponent
+        CaptionLabel {}
+    }
+
+    Component {
+        id: headlineLabelComponent
+        HeadlineLabel {}
+    }
+
+    Component {
+        id: subheadingLabelComponent
+        SubheadingLabel {}
+    }
+
+    Component {
+        id: titleLabelComponent
+        TitleLabel {}
+    }
+
+    function test_display_label() {
+        var displayLabel = displayLabelComponent.createObject(testCase)
+        verify(displayLabel)
+
+        // FIXME: We can't apparently access +material from tests,
+        // hence these test will fail
+        return
+
+        displayLabel.level = 1
+        compare(displayLabel.font.pixelSize, 34)
+        compare(displayLabel.font.weight, Font.Normal)
+        displayLabel.level = 2
+        compare(displayLabel.font.pixelSize, 45)
+        compare(displayLabel.font.weight, Font.Normal)
+        displayLabel.level = 3
+        compare(displayLabel.font.pixelSize, 56)
+        compare(displayLabel.font.weight, Font.Normal)
+        displayLabel.level = 4
+        compare(displayLabel.font.pixelSize, 112)
+        compare(displayLabel.font.weight, Font.Light)
+    }
+
+    function test_body_label() {
+        var bodyLabel = bodyLabelComponent.createObject(testCase)
+        verify(bodyLabel)
+
+        // FIXME: We can't apparently access +material from tests,
+        // hence these test will fail
+        return
+
+        bodyLabel.level = 1
+        if (Device.isMobile)
+            compare(bodyLabel.font.pixelSize, 14)
+        else
+            compare(bodyLabel.font.pixelSize, 13)
+        compare(bodyLabel.lineHeight, 20.0)
+        compare(bodyLabel.lineHeightMode, Text.FixedHeight)
+
+        bodyLabel.level = 2
+        if (Device.isMobile)
+            compare(bodyLabel.font.pixelSize, 14)
+        else
+            compare(bodyLabel.font.pixelSize, 13)
+        compare(bodyLabel.lineHeight, 24.0)
+        compare(bodyLabel.lineHeightMode, Text.FixedHeight)
+    }
+
+    function test_caption_label() {
+        var captionLabel = captionLabelComponent.createObject(testCase)
+        verify(captionLabel)
+
+        // FIXME: We can't apparently access +material from tests,
+        // hence these test will fail
+        return
+
+        compare(captionLabel.font.pixelSize, 12)
+    }
+
+    function test_headline_label() {
+        var headlineLabel = headlineLabelComponent.createObject(testCase)
+        verify(headlineLabel)
+
+        // FIXME: We can't apparently access +material from tests,
+        // hence these test will fail
+        return
+
+        compare(headlineLabel.font.pixelSize, 24)
+        compare(headlineLabel.lineHeight, 32.0)
+        compare(headlineLabel.lineHeightMode, Text.FixedHeight)
+    }
+
+    function test_subheading_label() {
+        var subheadingLabel = subheadingLabelComponent.createObject(testCase)
+        verify(subheadingLabel)
+
+        // FIXME: We can't apparently access +material from tests,
+        // hence these test will fail
+        return
+
+        subheadingLabel.level = 1
+        if (Device.isMobile)
+            compare(subheadingLabel.font.pixelSize, 16)
+        else
+            compare(subheadingLabel.font.pixelSize, 15)
+        compare(subheadingLabel.lineHeight, 24.0)
+        compare(subheadingLabel.lineHeightMode, Text.FixedHeight)
+
+        subheadingLabel.level = 2
+        if (Device.isMobile)
+            compare(subheadingLabel.font.pixelSize, 16)
+        else
+            compare(subheadingLabel.font.pixelSize, 15)
+        compare(subheadingLabel.lineHeight, 28.0)
+        compare(subheadingLabel.lineHeightMode, Text.FixedHeight)
+    }
+
+    function test_title_label() {
+        var titleLabel = titleLabelComponent.createObject(testCase)
+        verify(titleLabel)
+
+        // FIXME: We can't apparently access +material from tests,
+        // hence these test will fail
+        return
+
+        compare(titleLabel.font.pixelSize, 20)
+        compare(titleLabel.font.weight, Font.Medium)
+    }
+}

--- a/ui/+material/BodyLabel.qml
+++ b/ui/+material/BodyLabel.qml
@@ -1,0 +1,28 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.4
+import QtQuick.Templates 2.0 as T
+import QtQuick.Controls.Material 2.0
+import Fluid.Core 1.0
+
+T.Label {
+    property int level: 1
+
+    font.pixelSize: Device.isMobile ? 14 : 13
+    font.weight: level == 1 ? Font.Normal : Font.Medium
+    lineHeight: level <= 1 ? 20.0 : 24.0
+    lineHeightMode: Text.FixedHeight
+    linkColor: Material.accentColor
+    onLevelChanged: {
+        if (level < 1 || level > 2)
+            console.error("BodyLabel level must be either 1 or 2")
+    }
+}

--- a/ui/+material/CaptionLabel.qml
+++ b/ui/+material/CaptionLabel.qml
@@ -1,0 +1,18 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.4
+import QtQuick.Templates 2.0 as T
+import QtQuick.Controls.Material 2.0
+
+T.Label {
+    font.pixelSize: 12
+    linkColor: Material.accentColor
+}

--- a/ui/+material/DisplayLabel.qml
+++ b/ui/+material/DisplayLabel.qml
@@ -1,0 +1,46 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.4
+import QtQuick.Templates 2.0 as T
+import QtQuick.Controls.Material 2.0
+import Fluid.Core 1.0
+
+T.Label {
+    property int level: 1
+
+    font.pixelSize: {
+        if (level <= 1)
+            return 34
+        else if (level == 2)
+            return 45
+        else if (level == 3)
+            return 56
+        return 112
+    }
+    lineHeight: {
+        if (level <= 1)
+            return 40.0
+        else if (level == 2)
+            return 48.0
+        return 1.0
+    }
+    lineHeightMode: {
+        if (level <= 2)
+            return Text.FixedHeight
+        return Text.ProportionalHeight
+    }
+    font.weight: level >= 4 ? Font.Light : Font.Normal
+    linkColor: Material.accentColor
+    onLevelChanged: {
+        if (level < 1 || level > 4)
+            console.error("DisplayLabel level must be between 1 and 4")
+    }
+}

--- a/ui/+material/HeadlineLabel.qml
+++ b/ui/+material/HeadlineLabel.qml
@@ -1,0 +1,20 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.4
+import QtQuick.Templates 2.0 as T
+import QtQuick.Controls.Material 2.0
+
+T.Label {
+   font.pixelSize: 24
+   lineHeight: 32.0
+   lineHeightMode: Text.FixedHeight
+   linkColor: Material.accentColor
+}

--- a/ui/+material/SubheadingLabel.qml
+++ b/ui/+material/SubheadingLabel.qml
@@ -1,0 +1,27 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.4
+import QtQuick.Templates 2.0 as T
+import QtQuick.Controls.Material 2.0
+import Fluid.Core 1.0
+
+T.Label {
+    property int level: 1
+
+    font.pixelSize: Device.isMobile ? 16 : 15
+    lineHeight: level <= 1 ? 24.0 : 28.0
+    lineHeightMode: Text.FixedHeight
+    linkColor: Material.accentColor
+    onLevelChanged: {
+        if (level < 1 || level > 2)
+            console.error("SubheadingLabel level must be either 1 or 2 with the Material style")
+    }
+}

--- a/ui/+material/TitleLabel.qml
+++ b/ui/+material/TitleLabel.qml
@@ -1,0 +1,19 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.4
+import QtQuick.Templates 2.0 as T
+import QtQuick.Controls.Material 2.0
+
+T.Label {
+    font.pixelSize: 20
+    font.weight: Font.Medium
+    linkColor: Material.accentColor
+}

--- a/ui/BodyLabel.qml
+++ b/ui/BodyLabel.qml
@@ -1,0 +1,45 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.0
+import QtQuick.Templates 2.0 as T
+
+/*!
+    \qmltype BodyLabel
+    \inqmlmodule Fluid.UI 1.0
+    \brief Text label with standard font and styling suitable to body text.
+
+    \code
+    BodyLabel {
+        text: qsTr("Body text")
+    }
+    \endcode
+*/
+T.Label {
+    /*!
+        \qmlproperty int level
+
+        This property holds the label level that controls
+        font style and size.
+
+        It can be either 1 or 2.
+
+        Default value is 1.
+    */
+    property int level: 1
+
+    font.pixelSize: 14
+    color: "#26282a"
+    linkColor: "#45a7d7"
+    onLevelChanged: {
+        if (level < 1 || level > 2)
+            console.error("BodyLabel level must be either 1 or 2")
+    }
+}

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -3,8 +3,12 @@ set(FLUID_FILES
     Action.qml
     AppBar.qml
     AppToolBar.qml
+    BodyLabel.qml
+    CaptionLabel.qml
+    DisplayLabel.qml
     FluidStyle.qml
     FluidWindow.qml
+    HeadlineLabel.qml
     Icon.qml
     IconButton.qml
     Loadable.qml
@@ -14,8 +18,13 @@ set(FLUID_FILES
     Showable.qml
     SmoothFadeImage.qml
     SmoothFadeLoader.qml
+    SubheadingLabel.qml
+    TitleLabel.qml
     Units.qml
 )
 
 install(FILES ${FLUID_FILES}
+        DESTINATION ${QML_INSTALL_DIR}/Fluid/UI)
+
+install(DIRECTORY +material
         DESTINATION ${QML_INSTALL_DIR}/Fluid/UI)

--- a/ui/CaptionLabel.qml
+++ b/ui/CaptionLabel.qml
@@ -1,0 +1,29 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.0
+import QtQuick.Templates 2.0 as T
+
+/*!
+    \qmltype CaptionLabel
+    \inqmlmodule Fluid.UI 1.0
+    \brief Text label with standard font and styling suitable to captions.
+
+    \code
+    Caption {
+        text: qsTr("A translatable caption")
+    }
+    \endcode
+*/
+T.Label {
+    font.pixelSize: 10
+    color: "#26282a"
+    linkColor: "#45a7d7"
+}

--- a/ui/DisplayLabel.qml
+++ b/ui/DisplayLabel.qml
@@ -1,0 +1,53 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.0
+import QtQuick.Templates 2.0 as T
+
+/*!
+    \qmltype DisplayLabel
+    \inqmlmodule Fluid.UI 1.0
+    \brief Text label with standard font and styling suitable to display text.
+
+    \code
+    DisplayLabel {
+        text: qsTr("Display text")
+    }
+    \endcode
+*/
+T.Label {
+    /*!
+        \qmlproperty int level
+
+        This property holds the label level that controls
+        font style and size.
+
+        Only values between 1 and 4 are allowed.
+
+        Default value is 1.
+    */
+    property int level: 1
+
+    font.pixelSize: {
+        if (level <= 1)
+            return 30
+        else if (level == 2)
+            return 40
+        else if (level == 3)
+            return 50
+        return 100
+    }
+    color: "#26282a"
+    linkColor: "#45a7d7"
+    onLevelChanged: {
+        if (level < 1 || level > 4)
+            console.error("DisplayLabel level must be between 1 and 4")
+    }
+}

--- a/ui/HeadlineLabel.qml
+++ b/ui/HeadlineLabel.qml
@@ -1,0 +1,29 @@
+/*
+ * Fluid - QtQuick components for fluid and dynamic applications
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import QtQuick 2.0
+import QtQuick.Templates 2.0 as T
+
+/*!
+   \qmltype HeadlineLabel
+   \inqmlmodule Fluid.UI 1.0
+   \brief Text label with standard font and styling suitable to headlines.
+
+   \code
+   HeadlineLabel {
+       text: qsTr("A translatable headline")
+   }
+   \endcode
+*/
+T.Label {
+   font.pixelSize: 22
+   color: "#26282a"
+   linkColor: "#45a7d7"
+}

--- a/ui/SubheadingLabel.qml
+++ b/ui/SubheadingLabel.qml
@@ -1,0 +1,45 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.0
+import QtQuick.Templates 2.0 as T
+
+/*!
+    \qmltype SubheadingLabel
+    \inqmlmodule Fluid.UI 1.0
+    \brief Text label with standard font and styling suitable to subheading.
+
+    \code
+    SubheadingLabel {
+        text: qsTr("A translatable subheading")
+    }
+    \endcode
+*/
+T.Label {
+    /*!
+        \qmlproperty int level
+
+        This property holds the label level that controls
+        font style and size.
+
+        Only values between 1 and 4 are allowed.
+
+        Default value is 1.
+    */
+    property int level: 1
+
+    font.pixelSize: 14
+    color: "#26282a"
+    linkColor: "#45a7d7"
+    onLevelChanged: {
+        if (level < 1 || level > 2)
+            console.error("BodyLabel level must be either 1 or 2")
+    }
+}

--- a/ui/TitleLabel.qml
+++ b/ui/TitleLabel.qml
@@ -1,0 +1,30 @@
+ /*
+  * Fluid - QtQuick components for fluid and dynamic applications
+  *
+  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+  *
+  * This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  */
+
+import QtQuick 2.0
+import QtQuick.Templates 2.0 as T
+
+/*!
+    \qmltype TitleLabel
+    \inqmlmodule Fluid.UI 1.0
+    \brief Text label with standard font and styling suitable to titles.
+
+    \code
+    Title {
+        text: qsTr("Translatable title")
+    }
+    \endcode
+*/
+T.Label {
+    font.pixelSize: 18
+    font.bold: true
+    color: "#26282a"
+    linkColor: "#45a7d7"
+}

--- a/ui/qmldir
+++ b/ui/qmldir
@@ -2,7 +2,11 @@ module Fluid.UI
 Action 1.0 Action.qml
 AppBar 1.0 AppBar.qml
 AppToolBar 1.0 AppToolBar.qml
+BodyLabel 1.0 BodyLabel.qml
+CaptionLabel 1.0 CaptionLabel.qml
+DisplayLabel 1.0 DisplayLabel.qml
 FluidWindow 1.0 FluidWindow.qml
+HeadlineLabel 1.0 HeadlineLabel.qml
 Icon 1.0 Icon.qml
 IconButton 1.0 IconButton.qml
 Loadable 1.0 Loadable.qml
@@ -12,5 +16,7 @@ PageStack 1.0 PageStack.qml
 Showable 1.0 Showable.qml
 SmoothFadeImage 1.0 SmoothFadeImage.qml
 SmoothFadeLoader 1.0 SmoothFadeLoader.qml
+SubheadingLabel 1.0 SubheadingLabel.qml
+TitleLabel 1.0 TitleLabel.qml
 singleton FluidStyle 1.0 FluidStyle.qml
 singleton Units 1.0 Units.qml


### PR DESCRIPTION
Add a bunch of standard components for text.

Relying on FluidStyle properties for standard font settings
might be confusing for new users while a set of components will
make the choice obvious.

Individual text components allows us to set font properties
and line heights according to the guidelines automatically.