### PR TITLE
Relicense everything to MPL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Fluid
 
 [![ZenHub.io](https://img.shields.io/badge/supercharged%20by-zenhub.io-blue.svg)](https://zenhub.io)
 
-[![License](https://img.shields.io/badge/license-LGPLv2.1%2B-blue.svg)](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+[![License](https://img.shields.io/badge/license-MPL2%2B-blue.svg)](https://www.mozilla.org/en-US/MPL/2.0/)
 [![GitHub release](https://img.shields.io/github/release/qmlos/fluid.svg)](https://github.com/qmlos/fluid)
 [![Build Status](https://travis-ci.org/qmlos/fluid.svg?branch=develop)](https://travis-ci.org/qmlos/fluid)
 [![GitHub issues](https://img.shields.io/github/issues/qmlos/fluid.svg)](https://github.com/qmlos/fluid/issues)
@@ -50,5 +50,4 @@ On the `cmake` line, you can specify additional configuration parameters:
 
 ## Licensing
 
-Licensed under the terms of the GNU Lesser General Public License version 2.1 or,
-at your option, any later version.
+Licensed under the terms of the Mozilla Public License version 2.0.

--- a/controls/+material/BaseListItem.qml
+++ b/controls/+material/BaseListItem.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/+material/BodyLabel.qml
+++ b/controls/+material/BodyLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.4
 import QtQuick.Templates 2.0 as T

--- a/controls/+material/CaptionLabel.qml
+++ b/controls/+material/CaptionLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.4
 import QtQuick.Templates 2.0 as T

--- a/controls/+material/DisplayLabel.qml
+++ b/controls/+material/DisplayLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.4
 import QtQuick.Templates 2.0 as T

--- a/controls/+material/HeadlineLabel.qml
+++ b/controls/+material/HeadlineLabel.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/+material/SubheadingLabel.qml
+++ b/controls/+material/SubheadingLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.4
 import QtQuick.Templates 2.0 as T

--- a/controls/+material/ThinDivider.qml
+++ b/controls/+material/ThinDivider.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/+material/TitleLabel.qml
+++ b/controls/+material/TitleLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.4
 import QtQuick.Templates 2.0 as T

--- a/controls/Action.qml
+++ b/controls/Action.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/AppBar.qml
+++ b/controls/AppBar.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.0

--- a/controls/AppToolBar.qml
+++ b/controls/AppToolBar.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.0

--- a/controls/BaseListItem.qml
+++ b/controls/BaseListItem.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/BodyLabel.qml
+++ b/controls/BodyLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.0
 import QtQuick.Templates 2.0 as T

--- a/controls/CaptionLabel.qml
+++ b/controls/CaptionLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.0
 import QtQuick.Templates 2.0 as T

--- a/controls/CircleImage.qml
+++ b/controls/CircleImage.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/DisplayLabel.qml
+++ b/controls/DisplayLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.0
 import QtQuick.Templates 2.0 as T

--- a/controls/FluidStyle.qml
+++ b/controls/FluidStyle.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.0

--- a/controls/FluidWindow.qml
+++ b/controls/FluidWindow.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/HeadlineLabel.qml
+++ b/controls/HeadlineLabel.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.0

--- a/controls/Icon.qml
+++ b/controls/Icon.qml
@@ -1,13 +1,17 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
-  *               2015 Bogdan Cuza <bogdan.cuza@hotmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2015 Bogdan Cuza <bogdan.cuza@hotmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.4
 import QtQuick.Window 2.2

--- a/controls/IconButton.qml
+++ b/controls/IconButton.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.0

--- a/controls/ListItem.qml
+++ b/controls/ListItem.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/ListItemDelegate.qml
+++ b/controls/ListItemDelegate.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/Loadable.qml
+++ b/controls/Loadable.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2015-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 import QtQuick 2.0
 

--- a/controls/NoiseBackground.qml
+++ b/controls/NoiseBackground.qml
@@ -1,33 +1,21 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2013-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 /****************************************************************************
 **
-** Copyright (C) 2012 Digia Plc and/or its subsidiary(-ies).
-** Contact: http://www.qt-project.org/legal
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
 **
 ** This file is part of Fluid and is derived from NoisyGradient.qml
 ** from the Qt 5 launch demo.
@@ -44,7 +32,7 @@
 **     notice, this list of conditions and the following disclaimer in
 **     the documentation and/or other materials provided with the
 **     distribution.
-**   * Neither the name of Digia Plc and its Subsidiary(-ies) nor the names
+**   * Neither the name of The Qt Company nor the names
 **     of its contributors may be used to endorse or promote products derived
 **     from this software without specific prior written permission.
 **

--- a/controls/Page.qml
+++ b/controls/Page.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/PageStack.qml
+++ b/controls/PageStack.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/Showable.qml
+++ b/controls/Showable.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2015-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 import QtQuick 2.0
 

--- a/controls/SmoothFadeImage.qml
+++ b/controls/SmoothFadeImage.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2013-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 import QtQuick 2.0
 

--- a/controls/SmoothFadeLoader.qml
+++ b/controls/SmoothFadeLoader.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 import QtQuick 2.0
 

--- a/controls/Subheader.qml
+++ b/controls/Subheader.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/SubheadingLabel.qml
+++ b/controls/SubheadingLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.0
 import QtQuick.Templates 2.0 as T

--- a/controls/ThinDivider.qml
+++ b/controls/ThinDivider.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/controls/TitleLabel.qml
+++ b/controls/TitleLabel.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.0
 import QtQuick.Templates 2.0 as T

--- a/controls/Units.qml
+++ b/controls/Units.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 pragma Singleton
 

--- a/core/Object.qml
+++ b/core/Object.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2015-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 import QtQuick 2.0
 

--- a/core/Utils.qml
+++ b/core/Utils.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.0

--- a/core/clipboard.cpp
+++ b/core/clipboard.cpp
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #include "clipboard.h"

--- a/core/clipboard.h
+++ b/core/clipboard.h
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #pragma once

--- a/core/device.cpp
+++ b/core/device.cpp
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #include "device.h"

--- a/core/device.h
+++ b/core/device.h
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #pragma once

--- a/core/plugin.cpp
+++ b/core/plugin.cpp
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 #include <QtQml/qqml.h>
 #include <QtQml/QQmlExtensionPlugin>

--- a/core/standardpaths.cpp
+++ b/core/standardpaths.cpp
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 #include <QtCore/QStandardPaths>
 

--- a/core/standardpaths.h
+++ b/core/standardpaths.h
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2014-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 #ifndef STANDARDPATHS_H
 #define STANDARDPATHS_H

--- a/demo/SubPage.qml
+++ b/demo/SubPage.qml
@@ -1,3 +1,17 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
 import QtQuick.Controls 2.0
 import Fluid.Controls 1.0
 

--- a/demo/TypographyPage.qml
+++ b/demo/TypographyPage.qml
@@ -1,12 +1,16 @@
- /*
-  * Fluid - QtQuick components for fluid and dynamic applications
-  *
-  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
-  *
-  * This Source Code Form is subject to the terms of the Mozilla Public
-  * License, v. 2.0. If a copy of the MPL was not distributed with this
-  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  */
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
 
 import QtQuick 2.0
 import QtQuick.Layouts 1.0

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1,3 +1,17 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQuickStyle>

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -1,3 +1,18 @@
+/*
+ * This file is part of Fluid.
+ *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
+ */
+
 import QtQuick 2.6
 import QtQuick.Controls 2.0
 import Fluid.Controls 1.0

--- a/effects/CircleMask.qml
+++ b/effects/CircleMask.qml
@@ -1,11 +1,16 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
- * Copyright (C) 2015-2016 Michael Spencer <sonrisesoftware@gmail.com>
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/effects/Vignette.qml
+++ b/effects/Vignette.qml
@@ -1,28 +1,16 @@
-/****************************************************************************
+/*
  * This file is part of Fluid.
  *
- * Copyright (C) 2013-2016 Pier Luigi Fiorini
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  *
- * Author(s):
- *    Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ * $BEGIN_LICENSE:MPL2$
  *
- * $BEGIN_LICENSE:LGPL2.1+$
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  * $END_LICENSE$
- ***************************************************************************/
+ */
 
 import QtQuick 2.0
 

--- a/material/Ripple.qml
+++ b/material/Ripple.qml
@@ -1,11 +1,16 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
+ * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/tests/auto/controls/controls.cpp
+++ b/tests/auto/controls/controls.cpp
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #include <QtQuickTest/QtQuickTest>

--- a/tests/auto/controls/tst_icon.qml
+++ b/tests/auto/controls/tst_icon.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/tests/auto/controls/tst_listitem.qml
+++ b/tests/auto/controls/tst_listitem.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/tests/auto/core/core.cpp
+++ b/tests/auto/core/core.cpp
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #include <QtQuickTest/QtQuickTest>

--- a/tests/auto/core/tst_clipboard.qml
+++ b/tests/auto/core/tst_clipboard.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/tests/auto/core/tst_utils.qml
+++ b/tests/auto/core/tst_utils.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/tests/auto/material/material.cpp
+++ b/tests/auto/material/material.cpp
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 #include <QtQuickTest/QtQuickTest>

--- a/tests/auto/material/tst_ripple.qml
+++ b/tests/auto/material/tst_ripple.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4

--- a/tests/auto/material/tst_typography.qml
+++ b/tests/auto/material/tst_typography.qml
@@ -1,11 +1,15 @@
 /*
- * Fluid - QtQuick components for fluid and dynamic applications
+ * This file is part of Fluid.
  *
  * Copyright (C) 2016 Pier Luigi Fiorini <pierluigi.fiorini@gmail.com>
+ *
+ * $BEGIN_LICENSE:MPL2$
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * $END_LICENSE$
  */
 
 import QtQuick 2.4


### PR DESCRIPTION
While we are here we set the copyright year to 2016, it will be
easier in the future as it can be increased with a simple script.